### PR TITLE
feat: Create Halifax Housing Price Simulator

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Halifax Housing Price Simulation</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Halifax Housing Price Simulation</h1>
+        <p>Forecast to 2035 Based on Economic Scenarios</p>
+
+        <div class="controls">
+            <h2>Simulation Controls</h2>
+            <div class="control-group">
+                <label for="scenario">Select Forecast Scenario:</label>
+                <select id="scenario">
+                    <option value="cmhc-bau">CMHC (Business-as-Usual)</option>
+                    <option value="cmhc-is">CMHC (Increased Supply)</option>
+                    <option value="imf">IMF (Economic Factors)</option>
+                </select>
+                <p id="scenario-desc">High growth based on current supply and demand trends, leading to decreased affordability.</p>
+            </div>
+
+            <div id="imf-controls" class="hidden">
+                <div class="control-group">
+                    <label for="pop-growth">Annual Population Growth: <span id="pop-growth-value">2.0</span>%</label>
+                    <input type="range" id="pop-growth" min="0" max="5" step="0.1" value="2.0">
+                </div>
+                <div class="control-group">
+                    <label for="interest-rate">Average Annual Interest Rate: <span id="interest-rate-value">3.50</span>%</label>
+                    <input type="range" id="interest-rate" min="1" max="10" step="0.25" value="3.50">
+                </div>
+                <div class="control-group">
+                    <label for="new-housing">New Housing Units Per Year: <span id="new-housing-value">5000</span></label>
+                    <input type="range" id="new-housing" min="1000" max="10000" step="100" value="5000">
+                </div>
+            </div>
+        </div>
+
+        <div class="results">
+            <h2>Results</h2>
+            <div class="result-item">
+                <span>Projected 2035 Price</span>
+                <span id="projected-price">$415,520.4</span>
+            </div>
+            <div class="result-item">
+                <span>Total Growth</span>
+                <span id="total-growth">-33.5%</span>
+            </div>
+        </div>
+
+        <div class="disclaimer">
+            <p><strong>Disclaimer:</strong> This is a simplified model for illustrative purposes and not financial advice. Projections are based on public data from CMHC, IMF, and other sources as of mid-2025.</p>
+            <p><strong>Model Assumptions:</strong> Base Price (2025): $625,000. CMHC Scenarios: Growth rates are derived from CMHC reports on affordability and supply targets. "Business-as-Usual" implies prices grow significantly faster than incomes. "Increased Supply" assumes a balanced market. IMF Scenario: A formulaic model where price growth = 1.5% + (1.5 * Pop. Growth) - (2.0 * Interest Rate) - (0.0005 * (New Supply - 4700)).</p>
+        </div>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,159 @@
+document.addEventListener('DOMContentLoaded', () => {
+    // --- DOM Element References ---
+    const scenarioSelect = document.getElementById('scenario');
+    const scenarioDesc = document.getElementById('scenario-desc');
+    const imfControls = document.getElementById('imf-controls');
+
+    const popGrowthSlider = document.getElementById('pop-growth');
+    const popGrowthValue = document.getElementById('pop-growth-value');
+    const interestRateSlider = document.getElementById('interest-rate');
+    const interestRateValue = document.getElementById('interest-rate-value');
+    const newHousingSlider = document.getElementById('new-housing');
+    const newHousingValue = document.getElementById('new-housing-value');
+
+    const projectedPriceEl = document.getElementById('projected-price');
+    const totalGrowthEl = document.getElementById('total-growth');
+
+    // --- Constants and Initial State ---
+    const BASE_PRICE = 625000;
+    const START_YEAR = 2025;
+    const END_YEAR = 2035;
+    const YEARS = END_YEAR - START_YEAR;
+
+    const SCENARIO_DESCRIPTIONS = {
+        'cmhc-bau': 'High growth based on current supply and demand trends, leading to decreased affordability.',
+        'cmhc-is': 'Moderate growth assuming housing construction doubles to meet demand.',
+        'imf': 'Growth is driven by the economic variables you set below.'
+    };
+
+    // --- Core Functions ---
+
+    /**
+     * Calculates the projected price and total growth based on current inputs.
+     */
+    function calculateProjection() {
+        const scenario = scenarioSelect.value;
+        let annualGrowthRate = 0;
+
+        switch (scenario) {
+            case 'cmhc-bau':
+                // "Significantly faster than incomes" - let's assume a 5.5% annual growth.
+                annualGrowthRate = 0.055;
+                break;
+            case 'cmhc-is':
+                // "Balanced market" - let's assume a more modest 1.8% annual growth.
+                annualGrowthRate = 0.018;
+                break;
+            case 'imf':
+                const popGrowth = parseFloat(popGrowthSlider.value);
+                const interestRate = parseFloat(interestRateSlider.value);
+                const newSupply = parseInt(newHousingSlider.value, 10);
+
+                // Formula: price growth = 1.5% + (1.5 * Pop. Growth) - (2.0 * Interest Rate) - (0.0005 * (New Supply - 4700))
+                console.log(`JS DEBUG: popGrowth=${popGrowth}, interestRate=${interestRate}, newSupply=${newSupply}`);
+                const growthPercent = 1.5 + (1.5 * popGrowth) - (2.0 * interestRate) - (0.0005 * (newSupply - 4700));
+                console.log(`JS DEBUG: Calculated growthPercent=${growthPercent}`);
+                annualGrowthRate = growthPercent / 100;
+                break;
+        }
+
+        // Apply compound annual growth rate
+        const projectedPrice = BASE_PRICE * Math.pow((1 + annualGrowthRate), YEARS);
+        const totalGrowth = ((projectedPrice / BASE_PRICE) - 1) * 100;
+
+        updateResults(projectedPrice, totalGrowth);
+    }
+
+    /**
+     * Updates the results display with the calculated values.
+     * @param {number} price - The projected price.
+     * @param {number} growth - The total growth percentage.
+     */
+    function updateResults(price, growth) {
+        projectedPriceEl.textContent = formatCurrency(price);
+        totalGrowthEl.textContent = `${growth.toFixed(1)}%`;
+
+        // Change color based on growth
+        if (growth < 0) {
+            totalGrowthEl.style.color = '#dc3545'; // Red for negative
+        } else {
+            totalGrowthEl.style.color = '#007bff'; // Blue for positive
+        }
+    }
+
+    /**
+     * Handles changes to the selected scenario.
+     */
+    function handleScenarioChange() {
+        const selectedScenario = scenarioSelect.value;
+        scenarioDesc.textContent = SCENARIO_DESCRIPTIONS[selectedScenario];
+
+        if (selectedScenario === 'imf') {
+            imfControls.classList.remove('hidden');
+        } else {
+            imfControls.classList.add('hidden');
+        }
+        calculateProjection();
+    }
+
+    /**
+     * Updates the text display for a range slider.
+     * @param {HTMLElement} slider - The slider input element.
+     * @param {HTMLElement} valueEl - The element to display the value.
+     * @param {number} decimals - The number of decimal places to show.
+     * @param {string} unit - The unit to append (e.g., '%').
+     */
+    function updateSliderValue(slider, valueEl, decimals = 1, unit = '') {
+        valueEl.textContent = parseFloat(slider.value).toFixed(decimals);
+    }
+
+
+    // --- Event Listeners ---
+    scenarioSelect.addEventListener('change', handleScenarioChange);
+
+    popGrowthSlider.addEventListener('input', () => {
+        updateSliderValue(popGrowthSlider, popGrowthValue, 1);
+        calculateProjection();
+    });
+
+    interestRateSlider.addEventListener('input', () => {
+        updateSliderValue(interestRateSlider, interestRateValue, 2);
+        calculateProjection();
+    });
+
+    newHousingSlider.addEventListener('input', () => {
+        updateSliderValue(newHousingSlider, newHousingValue, 0);
+        calculateProjection();
+    });
+
+
+    // --- Utility Functions ---
+    /**
+     * Formats a number as a currency string (USD).
+     * @param {number} value - The number to format.
+     */
+    function formatCurrency(value) {
+        return new Intl.NumberFormat('en-US', {
+            style: 'currency',
+            currency: 'USD',
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
+        }).format(value);
+    }
+
+    // --- Initial Setup ---
+    function initialize() {
+        // Set initial slider values display
+        updateSliderValue(popGrowthSlider, popGrowthValue, 1);
+        updateSliderValue(interestRateSlider, interestRateValue, 2);
+        updateSliderValue(newHousingSlider, newHousingValue, 0);
+
+        // Set initial scenario description
+        scenarioDesc.textContent = SCENARIO_DESCRIPTIONS[scenarioSelect.value];
+
+        // Initial calculation
+        calculateProjection();
+    }
+
+    initialize();
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,117 @@
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background-color: #f4f7f9;
+    color: #333;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    margin: 0;
+    padding: 20px;
+}
+
+.container {
+    background-color: #fff;
+    padding: 30px;
+    border-radius: 10px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    max-width: 600px;
+    width: 100%;
+}
+
+h1 {
+    text-align: center;
+    color: #005a9c;
+    margin-top: 0;
+}
+
+h2 {
+    color: #005a9c;
+    border-bottom: 2px solid #e1e8ed;
+    padding-bottom: 10px;
+    margin-top: 30px;
+}
+
+p {
+    line-height: 1.6;
+}
+
+.controls, .results, .disclaimer {
+    margin-top: 20px;
+}
+
+.control-group {
+    margin-bottom: 20px;
+}
+
+.control-group label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: bold;
+}
+
+.control-group select, .control-group input[type="range"] {
+    width: 100%;
+    padding: 8px;
+    border-radius: 5px;
+    border: 1px solid #ccc;
+    box-sizing: border-box;
+}
+
+.control-group select {
+    appearance: none;
+    background: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23007CB2%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E') no-repeat right 10px center;
+    background-size: 12px;
+    padding-right: 30px;
+}
+
+#scenario-desc {
+    font-size: 0.9em;
+    color: #666;
+    margin-top: 5px;
+}
+
+.hidden {
+    display: none;
+}
+
+.results {
+    background-color: #e1f5fe;
+    border: 1px solid #b3e5fc;
+    padding: 20px;
+    border-radius: 5px;
+}
+
+.result-item {
+    display: flex;
+    justify-content: space-between;
+    font-size: 1.1em;
+    padding: 10px 0;
+}
+
+.result-item:not(:last-child) {
+    border-bottom: 1px solid #b3e5fc;
+}
+
+.result-item span:first-child {
+    font-weight: bold;
+    color: #01579b;
+}
+
+.result-item span:last-child {
+    font-weight: bold;
+    color: #007bff;
+    font-size: 1.2em;
+}
+
+.disclaimer {
+    margin-top: 30px;
+    font-size: 0.8em;
+    color: #666;
+    border-top: 1px solid #eee;
+    padding-top: 15px;
+}
+
+.disclaimer p {
+    margin: 5px 0;
+}


### PR DESCRIPTION
This commit introduces a complete, interactive web-based simulator for forecasting Halifax housing prices to 2035 based on different economic scenarios.

The simulator includes:
- An HTML structure (`index.html`) for the user interface.
- CSS styling (`style.css`) for a clean and professional layout.
- JavaScript logic (`script.js`) to handle calculations and interactions for three distinct scenarios:
  1. CMHC (Business-as-Usual): A high-growth model.
  2. CMHC (Increased Supply): A moderate-growth model.
  3. IMF (Economic Factors): A dynamic model based on inputs you can configure for population growth, interest rates, and new housing supply.

The simulation provides real-time updates to the projected 2035 price and total growth percentage as you adjust the controls. The implementation also includes detailed model assumptions and a disclaimer as specified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a self-contained Halifax Housing Price Simulation page with scenario selection (CMHC BAU, CMHC Increased Supply, IMF).
  - Added IMF-specific sliders for population growth, interest rate, and new housing units, revealed when IMF is selected.
  - Displays projected 2035 price and total growth with dynamic updates and color-coded growth.
  - Included a clear scenario description and a detailed disclaimer of assumptions.

- Style
  - Implemented a responsive, modern UI with a centered card layout, polished form controls, and a highlighted results panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->